### PR TITLE
Relax ActiveRecord version constraints

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,15 +1,16 @@
 appraise '4.2' do
-  gem 'activerecord', '~> 4.2.0'
+  gem 'activerecord', '~> 4.2'
 end
 
 appraise '5.0' do
-  gem 'activerecord', '~> 5.0.0'
+  gem 'activerecord', '~> 5.0'
 end
 
 appraise '5.1' do
-  gem 'activerecord', '~> 5.1.0'
+  gem 'activerecord', '~> 5.1'
 end
 
 appraise '5.2' do
-  gem 'activerecord', '~> 5.2.0'
+  gem 'activerecord', '~> 5.2'
 end
+

--- a/active_record_distinct_on.gemspec
+++ b/active_record_distinct_on.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['lib/**/*']
   spec.require_paths = %w{ lib }
 
-  spec.add_dependency 'activerecord', '>= 4.2', '<= 5.2'
+  spec.add_dependency 'activerecord', '>= 4.2', '< 6.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 4.2.0"
+gem "activerecord", "~> 4.2"
 
 gemspec path: "../"

--- a/gemfiles/4.2.gemfile.lock
+++ b/gemfiles/4.2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     active_record_distinct_on (0.1.4)
-      activerecord (>= 4.2, <= 5.2)
+      activerecord (>= 4.2, < 6.0)
 
 GEM
   remote: https://rubygems.org/
@@ -28,7 +28,7 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
-    docile (1.3.0)
+    docile (1.3.1)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
@@ -38,19 +38,19 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rake (10.5.0)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -67,7 +67,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_record_distinct_on!
-  activerecord (~> 4.2.0)
+  activerecord (~> 4.2)
   appraisal
   bundler (~> 1.10)
   pry
@@ -77,4 +77,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.1
+   1.16.4

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.0.0"
+gem "activerecord", "~> 5.0"
 
 gemspec path: "../"

--- a/gemfiles/5.0.gemfile.lock
+++ b/gemfiles/5.0.gemfile.lock
@@ -2,32 +2,32 @@ PATH
   remote: ..
   specs:
     active_record_distinct_on (0.1.4)
-      activerecord (>= 4.2, <= 5.2)
+      activerecord (>= 4.2, < 6.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.0.6)
-      activesupport (= 5.0.6)
-    activerecord (5.0.6)
-      activemodel (= 5.0.6)
-      activesupport (= 5.0.6)
-      arel (~> 7.0)
-    activesupport (5.0.6)
+    activemodel (5.2.1)
+      activesupport (= 5.2.1)
+    activerecord (5.2.1)
+      activemodel (= 5.2.1)
+      activesupport (= 5.2.1)
+      arel (>= 9.0)
+    activesupport (5.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     appraisal (2.2.0)
       bundler
       rake
       thor (>= 0.14.0)
-    arel (7.1.4)
+    arel (9.0.0)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
-    docile (1.3.0)
-    i18n (0.9.5)
+    docile (1.3.1)
+    i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     method_source (0.9.0)
@@ -36,19 +36,19 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rake (10.5.0)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -65,7 +65,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_record_distinct_on!
-  activerecord (~> 5.0.0)
+  activerecord (~> 5.0)
   appraisal
   bundler (~> 1.10)
   pry
@@ -75,4 +75,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.1
+   1.16.4

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.1.0"
+gem "activerecord", "~> 5.1"
 
 gemspec path: "../"

--- a/gemfiles/5.1.gemfile.lock
+++ b/gemfiles/5.1.gemfile.lock
@@ -2,32 +2,32 @@ PATH
   remote: ..
   specs:
     active_record_distinct_on (0.1.4)
-      activerecord (>= 4.2, <= 5.2)
+      activerecord (>= 4.2, < 6.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.1.5)
-      activesupport (= 5.1.5)
-    activerecord (5.1.5)
-      activemodel (= 5.1.5)
-      activesupport (= 5.1.5)
-      arel (~> 8.0)
-    activesupport (5.1.5)
+    activemodel (5.2.1)
+      activesupport (= 5.2.1)
+    activerecord (5.2.1)
+      activemodel (= 5.2.1)
+      activesupport (= 5.2.1)
+      arel (>= 9.0)
+    activesupport (5.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     appraisal (2.2.0)
       bundler
       rake
       thor (>= 0.14.0)
-    arel (8.0.0)
+    arel (9.0.0)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
-    docile (1.3.0)
-    i18n (0.9.5)
+    docile (1.3.1)
+    i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     method_source (0.9.0)
@@ -36,19 +36,19 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rake (10.5.0)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -65,7 +65,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_record_distinct_on!
-  activerecord (~> 5.1.0)
+  activerecord (~> 5.1)
   appraisal
   bundler (~> 1.10)
   pry
@@ -75,4 +75,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.1
+   1.16.4

--- a/gemfiles/5.2.gemfile
+++ b/gemfiles/5.2.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.2.0"
+gem "activerecord", "~> 5.2"
 
 gemspec path: "../"

--- a/gemfiles/5.2.gemfile.lock
+++ b/gemfiles/5.2.gemfile.lock
@@ -2,18 +2,18 @@ PATH
   remote: ..
   specs:
     active_record_distinct_on (0.1.4)
-      activerecord (>= 4.2, <= 5.2)
+      activerecord (>= 4.2, < 6.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.0)
-      activesupport (= 5.2.0)
-    activerecord (5.2.0)
-      activemodel (= 5.2.0)
-      activesupport (= 5.2.0)
+    activemodel (5.2.1)
+      activesupport (= 5.2.1)
+    activerecord (5.2.1)
+      activemodel (= 5.2.1)
+      activesupport (= 5.2.1)
       arel (>= 9.0)
-    activesupport (5.2.0)
+    activesupport (5.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -26,8 +26,8 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
-    docile (1.3.0)
-    i18n (1.0.1)
+    docile (1.3.1)
+    i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     method_source (0.9.0)
@@ -36,19 +36,19 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rake (10.5.0)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -65,7 +65,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_record_distinct_on!
-  activerecord (~> 5.2.0)
+  activerecord (~> 5.2)
   appraisal
   bundler (~> 1.10)
   pry
@@ -75,4 +75,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.1
+   1.16.4


### PR DESCRIPTION
This fixes #6 .

The constraints that I added in #5 were too restrictive. I'm optimistic that bugfix releases won't be an issue.

This also updates the appraisals to be against the latest version for every major.minor release.