### PR TITLE
Allow all of the Rails 6.0 series

### DIFF
--- a/active_record_distinct_on.gemspec
+++ b/active_record_distinct_on.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['lib/**/*']
   spec.require_paths = %w{ lib }
 
-  spec.add_dependency 'activerecord', '>= 4.2', '<= 6.0'
+  spec.add_dependency 'activerecord', '>= 4.2', '< 6.1'
 
   spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/gemfiles/4.2.gemfile.lock
+++ b/gemfiles/4.2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     active_record_distinct_on (0.1.6)
-      activerecord (>= 4.2, <= 6.0)
+      activerecord (>= 4.2, < 6.1)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/5.0.gemfile.lock
+++ b/gemfiles/5.0.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     active_record_distinct_on (0.1.6)
-      activerecord (>= 4.2, <= 6.0)
+      activerecord (>= 4.2, < 6.1)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/5.1.gemfile.lock
+++ b/gemfiles/5.1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     active_record_distinct_on (0.1.6)
-      activerecord (>= 4.2, <= 6.0)
+      activerecord (>= 4.2, < 6.1)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/5.2.gemfile.lock
+++ b/gemfiles/5.2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     active_record_distinct_on (0.1.6)
-      activerecord (>= 4.2, <= 6.0)
+      activerecord (>= 4.2, < 6.1)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/6.0.gemfile.lock
+++ b/gemfiles/6.0.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     active_record_distinct_on (0.1.6)
-      activerecord (>= 4.2, <= 6.0)
+      activerecord (>= 4.2, < 6.1)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
This fixes #10 .

It seems like hardest part of this gem is writing version constraints. :roll_eyes: I don't think we need to test again until Rails 6.1.

I'm going to defer this for now, but we should probably remove support for the 4.X series and re-evaluate whether a more elegant implementation exists.