### PR TITLE
Support count queries with joins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
         env:
           BUNDLE_GEMFILE: gemfiles/${{ matrix.rails }}.gemfile
         run: |
-          PGPASSWORD=password psql -c 'create database active_record_distinct_on_test;' -U postgres
+          PGPASSWORD=password psql -h localhost -U postgres -c 'create database active_record_distinct_on_test;'
           DATABASE_URL='postgresql://postgres:password@localhost/active_record_distinct_on_test' bundle exec rake
 
       - name: Upload Coverage Report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       postgres:
         image: postgres:13
         env:
-          POSTGRES_PASSWORD: ''
+          POSTGRES_PASSWORD: 'password'
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
@@ -73,8 +73,8 @@ jobs:
         env:
           BUNDLE_GEMFILE: gemfiles/${{ matrix.rails }}.gemfile
         run: |
-          psql -c 'create database active_record_distinct_on_test;' -U postgres
-          DATABASE_URL='postgresql://localhost/active_record_distinct_on_test' bundle exec rake
+          PGPASSWORD=password psql -c 'create database active_record_distinct_on_test;' -U postgres
+          DATABASE_URL='postgresql://postgres:password@localhost/active_record_distinct_on_test' bundle exec rake
 
       - name: Upload Coverage Report
         uses: aktions/codeclimate-test-reporter@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,20 @@ jobs:
           - { ruby: '3.0.2', rails: '6.1' }
           - { ruby: '3.0.2', rails: '7.0' }
 
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_PASSWORD: ''
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
     steps:
       - uses: actions/checkout@v2
       - name: Setup Ruby ${{ matrix.ruby }}
@@ -49,11 +63,18 @@ jobs:
           codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
           command: before-build
 
-      - name: Run Test Suite
+      - name: Run Test Suite (sqlite)
         env:
           BUNDLE_GEMFILE: gemfiles/${{ matrix.rails }}.gemfile
         run: |
           bundle exec rake
+
+      - name: Run Test Suite (postgres)
+        env:
+          BUNDLE_GEMFILE: gemfiles/${{ matrix.rails }}.gemfile
+        run: |
+          psql -c 'create database active_record_distinct_on_test;' -U postgres
+          DATABASE_URL='postgresql://localhost/active_record_distinct_on_test' bundle exec rake
 
       - name: Upload Coverage Report
         uses: aktions/codeclimate-test-reporter@v1

--- a/active_record_distinct_on.gemspec
+++ b/active_record_distinct_on.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'pg'
 end

--- a/spec/active_record_distinct_on/distinct_on_query_methods_spec.rb
+++ b/spec/active_record_distinct_on/distinct_on_query_methods_spec.rb
@@ -47,5 +47,42 @@ describe ActiveRecordDistinctOn::DistinctOnQueryMethods do
         expect(dummy_model.new.toys.scope.distinct_on_values).to eq [:id]
       end
     end
+
+    context '.count queries' do
+      it 'supports count queries in conjunction with distinct_on' do
+        dog = Dog.create!(
+          id: 1,
+          name: 'dogname',
+        )
+        toy = Toy.create!(
+          id: 2,
+          name: 'toyname',
+        )
+        2.times do
+          DogToToys.create!(
+            dog_id: dog.id,
+            toy_id: toy.id
+          )
+        end
+
+        expect(Dog.joins(:toys).count).to eq 2
+        expect(Dog.joins(:toys).where(name: 'dogname').count).to eq 2
+        expect(Dog.joins(:toys).where(name: 'toyname').count).to eq 0
+        expect(Dog.joins(:toys).where(toys: { name: 'toyname' }).count).to eq 2
+        expect(Dog.joins(:toys).distinct_on(:id).count).to eq 1
+        expect(Dog.joins(:toys).distinct_on(:id).where(name: 'dogname').count).to eq 1
+        expect(Dog.joins(:toys).distinct_on(:id).where(name: 'toyname').count).to eq 0
+        expect(Dog.joins(:toys).distinct_on(:id).where(toys: { name: 'toyname' }).count).to eq 1
+
+        expect(Dog.joins(:toys).size).to eq 2
+        expect(Dog.joins(:toys).where(name: 'dogname').size).to eq 2
+        expect(Dog.joins(:toys).where(name: 'toyname').size).to eq 0
+        expect(Dog.joins(:toys).where(toys: { name: 'toyname' }).size).to eq 2
+        expect(Dog.joins(:toys).distinct_on(:id).size).to eq 1
+        expect(Dog.joins(:toys).distinct_on(:id).where(name: 'dogname').size).to eq 1
+        expect(Dog.joins(:toys).distinct_on(:id).where(name: 'toyname').size).to eq 0
+        expect(Dog.joins(:toys).distinct_on(:id).where(toys: { name: 'toyname' }).size).to eq 1
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,13 +7,11 @@ require 'active_record_distinct_on'
 
 ActiveRecordDistinctOn.install
 
-ActiveRecord::Base.establish_connection(
-  adapter: 'sqlite3',
-  database: ':memory:'
-)
+database_url = ENV.fetch('DATABASE_URL', 'sqlite3::memory:')
+ActiveRecord::Base.establish_connection(database_url)
 
 ActiveRecord::Base.connection.execute(<<-SQL)
-  CREATE TABLE dogs (
+  CREATE TABLE IF NOT EXISTS dogs (
     id INTEGER PRIMARY KEY,
     name TEXT,
     toys_count INTEGER DEFAULT 0,
@@ -24,14 +22,14 @@ ActiveRecord::Base.connection.execute(<<-SQL)
 SQL
 
 ActiveRecord::Base.connection.execute(<<-SQL)
-  CREATE TABLE dog_to_toys (
+  CREATE TABLE IF NOT EXISTS dog_to_toys (
     dog_id INTEGER,
     toy_id INTEGER
   );
 SQL
 
 ActiveRecord::Base.connection.execute(<<-SQL)
-  CREATE TABLE toys (
+  CREATE TABLE IF NOT EXISTS toys (
     id INTEGER PRIMARY KEY,
     dog_to_toy_id INTEGER,
     name TEXT
@@ -49,4 +47,13 @@ class DogToToys < ActiveRecord::Base
 end
 
 class Toy < ActiveRecord::Base
+end
+
+RSpec.configure do |config|
+  config.before(:each) do
+    conn = ActiveRecord::Base.connection
+    conn.execute "delete from dogs;"
+    conn.execute "delete from dog_to_toys;"
+    conn.execute "delete from toys;"
+  end
 end


### PR DESCRIPTION
In our app, we have more complex scopes with joins + distinct_on that cause something like the following error when you call `.count` on it. This PR fixes this, and also runs against actual Postgres rather than SQLite to more proactively surface issues like these in the future.

```
ERROR:  column \"customers.id\" must appear in the GROUP BY clause or be used in an aggregate function
```