### PR TITLE
Added support for using an associations attribute

### DIFF
--- a/lib/active_record_distinct_on/distinct_on_query_methods.rb
+++ b/lib/active_record_distinct_on/distinct_on_query_methods.rb
@@ -1,5 +1,4 @@
 require 'active_record_distinct_on'
-
 module ActiveRecordDistinctOn
   module DistinctOnQueryMethods
     extend ActiveSupport::Concern
@@ -70,15 +69,26 @@ module ActiveRecordDistinctOn
     end
 
     def distinct_on_arel_columns
-      arel_attributes = distinct_on_values.map { |field|
-        if klass.attribute_alias?(field)
-          arel_table[klass.attribute_alias(field).to_sym]
+      arel_attributes = distinct_on_values.map do |field|
+        if field.is_a?(String)
+          field
+        elsif field.is_a?(Hash)
+          assoc = field.keys.first
+          assoc_klass = klass.reflect_on_association(assoc).klass
+          assoc_field = field[assoc].to_sym
+          build_distinct_on_field(assoc_klass, assoc_field)
         else
-          arel_table[field]
+          build_distinct_on_field(klass, field)
         end
-      }
+      end
 
-      arel_columns arel_attributes
+      arel_columns(arel_attributes)
+    end
+
+    def build_distinct_on_field(klass, field)
+      return klass.arel_table[klass.attribute_alias(field).to_sym] if klass.attribute_alias?(field)
+
+      klass.arel_table[field]
     end
   end
 end

--- a/spec/active_record_distinct_on/distinct_on_query_methods_spec.rb
+++ b/spec/active_record_distinct_on/distinct_on_query_methods_spec.rb
@@ -34,6 +34,38 @@ describe ActiveRecordDistinctOn::DistinctOnQueryMethods do
       end
     end
 
+    context 'with an associations attribute' do
+      
+      let(:arel) { subject.joins(:dog_to_toys).distinct_on(*attribute_names).arel }
+      let(:select_statement) { arel.ast }
+      let(:set_quantifies) { select_statement.cores.map(&:set_quantifier) }
+      let(:set_quantifier_attributes) { set_quantifies.flat_map(&:expr) }
+
+      context 'as an object' do
+        let(:attribute_names) { [:id, {dog_to_toys: :created_at}] }
+
+        it 'produces arel with a set_quantifier with the relations' do
+          expect(set_quantifier_attributes.first.relation.name).to eq "dogs"
+          expect(set_quantifier_attributes.first.name.to_sym).to eq :id
+
+          expect(set_quantifier_attributes.second.relation.name).to eq "dog_to_toys"
+          expect(set_quantifier_attributes.second.name.to_sym).to eq :created_at
+        end
+      end
+
+      context 'as a string' do
+        let(:attribute_names) { [:id, "dog_to_toys.created_at"] }
+
+        it 'produces arel with a set_quantifier with the relations' do
+          expect(set_quantifier_attributes.first.relation.name).to eq "dogs"
+          expect(set_quantifier_attributes.first.name.to_sym).to eq :id
+
+          expect(set_quantifier_attributes.second.relation.name).to eq "dog_to_toys"
+          expect(set_quantifier_attributes.second.name.to_sym).to eq :created_at
+        end
+      end
+    end
+
     context 'when chained' do
       it 'behaves the same as having been called once with all of the arguments' do
         expect(subject.distinct_on(:a).distinct_on(:b, :c).distinct_on_values).to(


### PR DESCRIPTION
This PR adds support for using `distinct_on` with attributes from joined associations.
Supports specifying attributes as a `Hash` or `String` for parity with other AR methods.

Eg. 
```ruby
Article.joins(:author).order(author: :id).distinct_on(:id, author: :id) # Given as Hash
Article.joins(:author).order(author: :id).distinct_on(:id, "authors.id") # Given as String
```

Fixes #22 