### PR TITLE
Fix distinct on count when more than one column is specified

### DIFF
--- a/lib/active_record_distinct_on/distinct_on_query_methods.rb
+++ b/lib/active_record_distinct_on/distinct_on_query_methods.rb
@@ -54,7 +54,7 @@ module ActiveRecordDistinctOn
           "\"#{col.relation.name}\".\"#{col.name}\""
         end
 
-        scope.count("distinct #{column_names.join(', ')}")
+        scope.count("distinct(#{column_names.join(', ')})")
       end
     end
 

--- a/spec/active_record_distinct_on/distinct_on_query_methods_spec.rb
+++ b/spec/active_record_distinct_on/distinct_on_query_methods_spec.rb
@@ -102,18 +102,18 @@ describe ActiveRecordDistinctOn::DistinctOnQueryMethods do
         expect(Dog.joins(:toys).where(name: 'toyname').count).to eq 0
         expect(Dog.joins(:toys).where(toys: { name: 'toyname' }).count).to eq 2
         expect(Dog.joins(:toys).distinct_on(:id).count).to eq 1
-        expect(Dog.joins(:toys).distinct_on(:id).where(name: 'dogname').count).to eq 1
-        expect(Dog.joins(:toys).distinct_on(:id).where(name: 'toyname').count).to eq 0
-        expect(Dog.joins(:toys).distinct_on(:id).where(toys: { name: 'toyname' }).count).to eq 1
+        expect(Dog.joins(:toys).distinct_on(:id, :name).where(name: 'dogname').count).to eq 1
+        expect(Dog.joins(:toys).distinct_on(:id, :name).where(name: 'toyname').count).to eq 0
+        expect(Dog.joins(:toys).distinct_on(:id, :name).where(toys: { name: 'toyname' }).count).to eq 1
 
         expect(Dog.joins(:toys).size).to eq 2
         expect(Dog.joins(:toys).where(name: 'dogname').size).to eq 2
         expect(Dog.joins(:toys).where(name: 'toyname').size).to eq 0
         expect(Dog.joins(:toys).where(toys: { name: 'toyname' }).size).to eq 2
-        expect(Dog.joins(:toys).distinct_on(:id).size).to eq 1
-        expect(Dog.joins(:toys).distinct_on(:id).where(name: 'dogname').size).to eq 1
-        expect(Dog.joins(:toys).distinct_on(:id).where(name: 'toyname').size).to eq 0
-        expect(Dog.joins(:toys).distinct_on(:id).where(toys: { name: 'toyname' }).size).to eq 1
+        expect(Dog.joins(:toys).distinct_on(:id, :name).size).to eq 1
+        expect(Dog.joins(:toys).distinct_on(:id, :name).where(name: 'dogname').size).to eq 1
+        expect(Dog.joins(:toys).distinct_on(:id, :name).where(name: 'toyname').size).to eq 0
+        expect(Dog.joins(:toys).distinct_on(:id, :name).where(toys: { name: 'toyname' }).size).to eq 1
       end
     end
   end


### PR DESCRIPTION
Hi,

We noticed that if you have more than one distinct on column, the count function is missing parentheses and therefore you get an error similar to ` function count(integer, uuid) does not exist`

This adds the brackets so that it works appropriately and changes the tests to include another parameter to check it